### PR TITLE
Apply Laravel coding style

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -10,7 +10,6 @@ class Kernel extends ConsoleKernel
     /**
      * Define the application's command schedule.
      *
-     * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
      * @return void
      */
     protected function schedule(Schedule $schedule)

--- a/app/Http/Controllers/Api/V1/CategoryController.php
+++ b/app/Http/Controllers/Api/V1/CategoryController.php
@@ -2,11 +2,11 @@
 
 namespace App\Http\Controllers\Api\V1;
 
-use App\Models\Category;
 use App\Http\Controllers\Controller;
-use App\Http\Resources\CategoryResource;
 use App\Http\Requests\StoreCategoryRequest;
 use App\Http\Requests\UpdateCategoryRequest;
+use App\Http\Resources\CategoryResource;
+use App\Models\Category;
 use App\Repositories\Category\CategoryRepository;
 
 class CategoryController extends Controller
@@ -33,7 +33,6 @@ class CategoryController extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * @param  \App\Http\Requests\StoreCategoryRequest  $request
      * @return \Illuminate\Http\Response
      */
     public function store(StoreCategoryRequest $request)
@@ -50,7 +49,6 @@ class CategoryController extends Controller
     /**
      * Display the specified resource.
      *
-     * @param  \App\Models\Category  $category
      * @return \Illuminate\Http\Response
      */
     public function show(Category $category)
@@ -61,20 +59,18 @@ class CategoryController extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @param  \App\Http\Requests\UpdateCategoryRequest  $request
-     * @param  \App\Models\Category  $category
      * @return \Illuminate\Http\Response
      */
     public function update(UpdateCategoryRequest $request, Category $category)
     {
         $category = $this->repository->updateCategory($category, $request->validated());
+
         return new CategoryResource($category);
     }
 
     /**
      * Remove the specified resource from storage.
      *
-     * @param  \App\Models\Category  $category
      * @return \Illuminate\Http\Response
      */
     public function destroy(Category $category)
@@ -82,6 +78,7 @@ class CategoryController extends Controller
         $this->authorize('delete', $category);
 
         $this->repository->deleteCategory($category);
+
         return response()->json('OK');
     }
 }

--- a/app/Http/Controllers/Api/V1/PostController.php
+++ b/app/Http/Controllers/Api/V1/PostController.php
@@ -2,12 +2,12 @@
 
 namespace App\Http\Controllers\Api\V1;
 
-use App\Models\Post;
 use App\Http\Controllers\Controller;
-use App\Http\Resources\PostResource;
-use App\Http\Resources\PostCollection;
 use App\Http\Requests\StorePostRequest;
 use App\Http\Requests\UpdatePostRequest;
+use App\Http\Resources\PostCollection;
+use App\Http\Resources\PostResource;
+use App\Models\Post;
 use App\Repositories\Post\PostRepository;
 
 class PostController extends Controller
@@ -32,7 +32,6 @@ class PostController extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * @param  \App\Http\Requests\StorePostRequest  $request
      * @return \Illuminate\Http\Response
      */
     public function store(StorePostRequest $request)
@@ -49,7 +48,6 @@ class PostController extends Controller
     /**
      * Display the specified resource.
      *
-     * @param  \App\Models\Post  $post
      * @return \Illuminate\Http\Response
      */
     public function show(Post $post)
@@ -60,20 +58,18 @@ class PostController extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @param  \App\Http\Requests\UpdatePostRequest  $request
-     * @param  \App\Models\Post  $post
      * @return \Illuminate\Http\Response
      */
     public function update(UpdatePostRequest $request, Post $post)
     {
         $post = $this->repository->updatePost($post, $request);
+
         return new PostResource($post);
     }
 
     /**
      * Remove the specified resource from storage.
      *
-     * @param  \App\Models\Post  $post
      * @return \Illuminate\Http\Response
      */
     public function destroy(Post $post)
@@ -81,6 +77,7 @@ class PostController extends Controller
         $this->authorize('delete', $post);
 
         $this->repository->deletePost($post);
+
         return response()->json('OK');
     }
 }

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -3,8 +3,8 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
-use App\Providers\RouteServiceProvider;
 use App\Models\User;
+use App\Providers\RouteServiceProvider;
 use Illuminate\Foundation\Auth\RegistersUsers;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
@@ -44,7 +44,6 @@ class RegisterController extends Controller
     /**
      * Get a validator for an incoming registration request.
      *
-     * @param  array  $data
      * @return \Illuminate\Contracts\Validation\Validator
      */
     protected function validator(array $data)
@@ -59,7 +58,6 @@ class RegisterController extends Controller
     /**
      * Create a new user instance after a valid registration.
      *
-     * @param  array  $data
      * @return \App\Models\User
      */
     protected function create(array $data)

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Category;
 use App\Http\Requests\StoreCategoryRequest;
 use App\Http\Requests\UpdateCategoryRequest;
+use App\Models\Category;
 use App\Repositories\Category\CategoryRepository;
 
 class CategoryController extends Controller
@@ -24,7 +24,7 @@ class CategoryController extends Controller
     public function index()
     {
         return view('category.index', [
-            'categories' => $this->repository->all()
+            'categories' => $this->repository->all(),
         ]);
     }
 
@@ -76,6 +76,7 @@ class CategoryController extends Controller
     public function update(UpdateCategoryRequest $request, Category $category)
     {
         $this->repository->updateCategory($category, $request->validated());
+
         return redirect()->route('categories.index');
     }
 

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -2,8 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
-
 class HomeController extends Controller
 {
     /**

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -2,11 +2,10 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Post;
-use App\Models\Category;
-use Illuminate\Support\Str;
 use App\Http\Requests\StorePostRequest;
 use App\Http\Requests\UpdatePostRequest;
+use App\Models\Category;
+use App\Models\Post;
 use App\Repositories\Post\PostRepository;
 
 class PostController extends Controller
@@ -26,7 +25,7 @@ class PostController extends Controller
     public function index()
     {
         return view('post.index', [
-            'posts' => $this->repository->all()
+            'posts' => $this->repository->all(),
         ]);
     }
 
@@ -38,14 +37,13 @@ class PostController extends Controller
     public function create()
     {
         return view('post.create', [
-            'categories' => Category::orderBy('name', "ASC")->get()
+            'categories' => Category::orderBy('name', 'ASC')->get(),
         ]);
     }
 
     /**
      * Store a newly created resource in storage.
      *
-     * @param  \App\Http\Requests\StorePostRequest  $request
      * @return \Illuminate\Http\Response
      */
     public function store(StorePostRequest $request)
@@ -62,7 +60,6 @@ class PostController extends Controller
     /**
      * Display the specified resource.
      *
-     * @param  \App\Models\Post  $post
      * @return \Illuminate\Http\Response
      */
     public function show(Post $post)
@@ -73,34 +70,31 @@ class PostController extends Controller
     /**
      * Show the form for editing the specified resource.
      *
-     * @param  \App\Models\Post  $post
      * @return \Illuminate\Http\Response
      */
     public function edit(Post $post)
     {
         return view('post.edit', [
             'post' => $post,
-            'categories' => Category::orderBy('name', "ASC")->get()
+            'categories' => Category::orderBy('name', 'ASC')->get(),
         ]);
     }
 
     /**
      * Update the specified resource in storage.
      *
-     * @param  \App\Http\Requests\UpdatePostRequest  $request
-     * @param  \App\Models\Post  $post
      * @return \Illuminate\Http\Response
      */
     public function update(UpdatePostRequest $request, Post $post)
     {
         $post = $this->repository->updatePost($post, $request);
+
         return redirect()->route('posts.show', ['post' => $post]);
     }
 
     /**
      * Remove the specified resource from storage.
      *
-     * @param  \App\Models\Post  $post
      * @return \Illuminate\Http\Response
      */
     public function destroy(Post $post)

--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -12,7 +12,6 @@ class RedirectIfAuthenticated
     /**
      * Handle an incoming request.
      *
-     * @param  \Illuminate\Http\Request  $request
      * @param  \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse)  $next
      * @param  string|null  ...$guards
      * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse

--- a/app/Http/Requests/StoreCategoryRequest.php
+++ b/app/Http/Requests/StoreCategoryRequest.php
@@ -25,7 +25,7 @@ class StoreCategoryRequest extends FormRequest
     public function rules()
     {
         return [
-            'name' => 'required|string|min:2|max:32'
+            'name' => 'required|string|min:2|max:32',
         ];
     }
 }

--- a/app/Http/Requests/UpdateCategoryRequest.php
+++ b/app/Http/Requests/UpdateCategoryRequest.php
@@ -24,7 +24,7 @@ class UpdateCategoryRequest extends FormRequest
     public function rules()
     {
         return [
-            'name' => 'required|string|min:2|max:32'
+            'name' => 'required|string|min:2|max:32',
         ];
     }
 }

--- a/app/Http/Resources/CategoryResource.php
+++ b/app/Http/Resources/CategoryResource.php
@@ -16,7 +16,7 @@ class CategoryResource extends JsonResource
     {
         return [
             'id' => $this->id,
-            'name' => $this->name
+            'name' => $this->name,
         ];
     }
 }

--- a/app/Http/Resources/PostResource.php
+++ b/app/Http/Resources/PostResource.php
@@ -19,7 +19,7 @@ class PostResource extends JsonResource
             'title' => $this->title,
             'content' => $this->content,
             'image' => $this->image,
-            'category' => new CategoryResource($this->category)
+            'category' => new CategoryResource($this->category),
         ];
     }
 }

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -2,22 +2,20 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class Category extends Model
 {
     use HasFactory;
 
     protected $fillable = [
-        'name'
+        'name',
     ];
 
     /**
      * Get the user that owns the Category
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function user(): BelongsTo
     {

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -2,12 +2,9 @@
 
 namespace App\Models;
 
-use App\Models\User;
-use App\Models\Category;
-use Illuminate\Support\Str;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class Post extends Model
 {
@@ -18,17 +15,15 @@ class Post extends Model
         'title',
         'content',
         'image',
-        'user_id'
+        'user_id',
     ];
 
     protected $with = [
-        'category'
+        'category',
     ];
 
     /**
      * Get the user that owns the Post
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function user(): BelongsTo
     {
@@ -37,8 +32,6 @@ class Post extends Model
 
     /**
      * Get the category that owns the Post
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function category(): BelongsTo
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,13 +2,11 @@
 
 namespace App\Models;
 
-use App\Models\Post;
-use Laravel\Sanctum\HasApiTokens;
-use Illuminate\Notifications\Notifiable;
-use Illuminate\Contracts\Auth\MustVerifyEmail;
-use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+use Laravel\Sanctum\HasApiTokens;
 
 class User extends Authenticatable
 {
@@ -46,8 +44,6 @@ class User extends Authenticatable
 
     /**
      * Get all of the categories for the User
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
     public function categories(): HasMany
     {
@@ -56,8 +52,6 @@ class User extends Authenticatable
 
     /**
      * Get all of the posts for the User
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
     public function posts(): HasMany
     {

--- a/app/Policies/CategoryPolicy.php
+++ b/app/Policies/CategoryPolicy.php
@@ -13,7 +13,6 @@ class CategoryPolicy
     /**
      * Determine whether the user can view any models.
      *
-     * @param  \App\Models\User  $user
      * @return \Illuminate\Auth\Access\Response|bool
      */
     public function viewAny(User $user)
@@ -24,8 +23,6 @@ class CategoryPolicy
     /**
      * Determine whether the user can view the model.
      *
-     * @param  \App\Models\User  $user
-     * @param  \App\Models\Category  $category
      * @return \Illuminate\Auth\Access\Response|bool
      */
     public function view(User $user, Category $category)
@@ -36,7 +33,6 @@ class CategoryPolicy
     /**
      * Determine whether the user can create models.
      *
-     * @param  \App\Models\User  $user
      * @return \Illuminate\Auth\Access\Response|bool
      */
     public function create(User $user)
@@ -47,8 +43,6 @@ class CategoryPolicy
     /**
      * Determine whether the user can update the model.
      *
-     * @param  \App\Models\User  $user
-     * @param  \App\Models\Category  $category
      * @return \Illuminate\Auth\Access\Response|bool
      */
     public function update(User $user, Category $category)
@@ -59,8 +53,6 @@ class CategoryPolicy
     /**
      * Determine whether the user can delete the model.
      *
-     * @param  \App\Models\User  $user
-     * @param  \App\Models\Category  $category
      * @return \Illuminate\Auth\Access\Response|bool
      */
     public function delete(User $user, Category $category)
@@ -71,8 +63,6 @@ class CategoryPolicy
     /**
      * Determine whether the user can restore the model.
      *
-     * @param  \App\Models\User  $user
-     * @param  \App\Models\Category  $category
      * @return \Illuminate\Auth\Access\Response|bool
      */
     public function restore(User $user, Category $category)
@@ -83,8 +73,6 @@ class CategoryPolicy
     /**
      * Determine whether the user can permanently delete the model.
      *
-     * @param  \App\Models\User  $user
-     * @param  \App\Models\Category  $category
      * @return \Illuminate\Auth\Access\Response|bool
      */
     public function forceDelete(User $user, Category $category)

--- a/app/Policies/PostPolicy.php
+++ b/app/Policies/PostPolicy.php
@@ -13,7 +13,6 @@ class PostPolicy
     /**
      * Determine whether the user can view any models.
      *
-     * @param  \App\Models\User  $user
      * @return \Illuminate\Auth\Access\Response|bool
      */
     public function viewAny(User $user)
@@ -24,8 +23,6 @@ class PostPolicy
     /**
      * Determine whether the user can view the model.
      *
-     * @param  \App\Models\User  $user
-     * @param  \App\Models\Post  $post
      * @return \Illuminate\Auth\Access\Response|bool
      */
     public function view(User $user, Post $post)
@@ -36,7 +33,6 @@ class PostPolicy
     /**
      * Determine whether the user can create models.
      *
-     * @param  \App\Models\User  $user
      * @return \Illuminate\Auth\Access\Response|bool
      */
     public function create(User $user)
@@ -47,8 +43,6 @@ class PostPolicy
     /**
      * Determine whether the user can update the model.
      *
-     * @param  \App\Models\User  $user
-     * @param  \App\Models\Post  $post
      * @return \Illuminate\Auth\Access\Response|bool
      */
     public function update(User $user, Post $post)
@@ -59,8 +53,6 @@ class PostPolicy
     /**
      * Determine whether the user can delete the model.
      *
-     * @param  \App\Models\User  $user
-     * @param  \App\Models\Post  $post
      * @return \Illuminate\Auth\Access\Response|bool
      */
     public function delete(User $user, Post $post)
@@ -71,8 +63,6 @@ class PostPolicy
     /**
      * Determine whether the user can restore the model.
      *
-     * @param  \App\Models\User  $user
-     * @param  \App\Models\Post  $post
      * @return \Illuminate\Auth\Access\Response|bool
      */
     public function restore(User $user, Post $post)
@@ -83,8 +73,6 @@ class PostPolicy
     /**
      * Determine whether the user can permanently delete the model.
      *
-     * @param  \App\Models\User  $user
-     * @param  \App\Models\Post  $post
      * @return \Illuminate\Auth\Access\Response|bool
      */
     public function forceDelete(User $user, Post $post)

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -2,10 +2,9 @@
 
 namespace App\Providers;
 
-use Laravel\Passport\Passport;
 use App\Models\Passport\Client;
-use Illuminate\Support\Facades\Gate;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use Laravel\Passport\Passport;
 
 class AuthServiceProvider extends ServiceProvider
 {

--- a/app/Providers/RepositoryServiceProvider.php
+++ b/app/Providers/RepositoryServiceProvider.php
@@ -2,11 +2,11 @@
 
 namespace App\Providers;
 
-use Illuminate\Support\ServiceProvider;
-use App\Repositories\Post\PostRepository;
 use App\Repositories\Category\CategoryRepository;
-use App\Repositories\Post\EloquentPostRepository;
 use App\Repositories\Category\EloquentCategoryRepository;
+use App\Repositories\Post\EloquentPostRepository;
+use App\Repositories\Post\PostRepository;
+use Illuminate\Support\ServiceProvider;
 
 class RepositoryServiceProvider extends ServiceProvider
 {

--- a/app/Repositories/Category/CategoryRepository.php
+++ b/app/Repositories/Category/CategoryRepository.php
@@ -2,14 +2,17 @@
 
 namespace App\Repositories\Category;
 
-use App\Models\User;
 use App\Models\Category;
+use App\Models\User;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 
 interface CategoryRepository
 {
     public function all(): LengthAwarePaginator;
+
     public function storeCategory(User $user, $array): Category;
+
     public function updateCategory(Category $category, $array): Category;
+
     public function deleteCategory(Category $category): bool;
 }

--- a/app/Repositories/Category/EloquentCategoryRepository.php
+++ b/app/Repositories/Category/EloquentCategoryRepository.php
@@ -2,9 +2,8 @@
 
 namespace App\Repositories\Category;
 
-use App\Models\User;
 use App\Models\Category;
-use App\Repositories\Category\CategoryRepository;
+use App\Models\User;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 
 class EloquentCategoryRepository implements CategoryRepository
@@ -22,6 +21,7 @@ class EloquentCategoryRepository implements CategoryRepository
     public function updateCategory(Category $category, $array): Category
     {
         $category->update($array);
+
         return $category;
     }
 

--- a/app/Repositories/Post/EloquentPostRepository.php
+++ b/app/Repositories/Post/EloquentPostRepository.php
@@ -2,13 +2,13 @@
 
 namespace App\Repositories\Post;
 
-use App\Models\Post;
-use App\Models\User;
-use Illuminate\Support\Str;
 use App\Http\Requests\StorePostRequest;
 use App\Http\Requests\UpdatePostRequest;
-use Illuminate\Foundation\Http\FormRequest;
+use App\Models\Post;
+use App\Models\User;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Str;
 
 class EloquentPostRepository implements PostRepository
 {
@@ -25,7 +25,7 @@ class EloquentPostRepository implements PostRepository
             'title' => $request->title,
             'content' => $request->content,
             'category_id' => $request->category,
-            'image' => $fileName
+            'image' => $fileName,
         ]);
     }
 
@@ -37,7 +37,7 @@ class EloquentPostRepository implements PostRepository
             'title' => $request->title,
             'content' => $request->content,
             'category_id' => $request->category,
-            'image' => $fileName
+            'image' => $fileName,
         ]);
 
         return $post;
@@ -50,12 +50,12 @@ class EloquentPostRepository implements PostRepository
 
     private function saveImage(FormRequest $request): string|null
     {
-        if (!$request->hasFile('image')) {
+        if (! $request->hasFile('image')) {
             return null;
         }
 
         $file = $request->file('image');
-        $fileName = Str::slug($request->title, '-') . '-' . $file->hashName();
+        $fileName = Str::slug($request->title, '-').'-'.$file->hashName();
 
         $file->storeAs('public', $fileName);
 

--- a/app/Repositories/Post/PostRepository.php
+++ b/app/Repositories/Post/PostRepository.php
@@ -2,16 +2,19 @@
 
 namespace App\Repositories\Post;
 
-use App\Models\Post;
-use App\Models\User;
 use App\Http\Requests\StorePostRequest;
 use App\Http\Requests\UpdatePostRequest;
+use App\Models\Post;
+use App\Models\User;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 
 interface PostRepository
 {
     public function all(): LengthAwarePaginator;
+
     public function storePost(User $user, StorePostRequest $request): Post;
+
     public function updatePost(Post $post, UpdatePostRequest $request): Post;
+
     public function deletePost(Post $post): bool;
 }

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -19,7 +19,7 @@ class CategoryFactory extends Factory
     {
         return [
             'user_id' => User::all()->random()->id,
-            'name' => $this->faker->word()
+            'name' => $this->faker->word(),
         ];
     }
 }

--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -2,8 +2,8 @@
 
 namespace Database\Factories;
 
-use App\Models\User;
 use App\Models\Category;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**

--- a/database/seeders/CategorySeeder.php
+++ b/database/seeders/CategorySeeder.php
@@ -2,7 +2,6 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class CategorySeeder extends Seeder

--- a/database/seeders/PostSeeder.php
+++ b/database/seeders/PostSeeder.php
@@ -2,7 +2,6 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class PostSeeder extends Seeder

--- a/routes/api/v1.php
+++ b/routes/api/v1.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Support\Facades\Route;
-use App\Http\Controllers\Api\V1\PostController;
 use App\Http\Controllers\Api\V1\CategoryController;
+use App\Http\Controllers\Api\V1\PostController;
+use Illuminate\Support\Facades\Route;
 
 /*
 |--------------------------------------------------------------------------
@@ -17,8 +17,8 @@ use App\Http\Controllers\Api\V1\CategoryController;
 
 Route::apiResources([
     'categories' => CategoryController::class,
-    'posts' => PostController::class
+    'posts' => PostController::class,
 ], [
     'middleware' => 'auth:api',
-    'as' => 'api'
+    'as' => 'api',
 ]);

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,9 +1,9 @@
 <?php
 
-use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\CategoryController;
 use App\Http\Controllers\PostController;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Route;
 
 /*
 |--------------------------------------------------------------------------
@@ -23,9 +23,8 @@ Route::redirect('', 'posts', 301);
 Route::middleware('auth')
     ->resource('categories', CategoryController::class)
     ->except([
-        'show'
+        'show',
     ]);
-
 
 Route::middleware('auth')
     ->resource('posts', PostController::class);

--- a/tests/Feature/Http/Controllers/Api/V1/CategoryControllerTest.php
+++ b/tests/Feature/Http/Controllers/Api/V1/CategoryControllerTest.php
@@ -2,14 +2,14 @@
 
 namespace Tests\Feature\Http\Controllers\Api\V1;
 
-use Tests\TestCase;
-use App\Models\User;
-use App\Models\Category;
 use App\Http\Middleware\Authenticate;
-use Illuminate\Foundation\Testing\WithFaker;
+use App\Models\Category;
+use App\Models\User;
 use App\Repositories\Category\CategoryRepository;
 use App\Repositories\Category\EloquentCategoryRepository;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
 
 class CategoryControllerTest extends TestCase
 {
@@ -23,7 +23,7 @@ class CategoryControllerTest extends TestCase
         parent::setUp();
 
         $this->user = User::factory()->create([
-            'email' => 'dummy@email.test'
+            'email' => 'dummy@email.test',
         ]);
 
         $this->withoutMiddleware(Authenticate::class);
@@ -41,7 +41,7 @@ class CategoryControllerTest extends TestCase
 
         $response->assertOk();
         $response->assertJsonFragment([
-            'name' => $categories->random()->name
+            'name' => $categories->random()->name,
         ]);
     }
 
@@ -56,7 +56,6 @@ class CategoryControllerTest extends TestCase
         $this->assertDatabaseHas('categories', $categoryName);
         $response->assertCreated();
         $response->assertJsonFragment($categoryName);
-
     }
 
     /** @test */
@@ -69,7 +68,7 @@ class CategoryControllerTest extends TestCase
 
         $response->assertOk();
         $response->assertJsonFragment([
-            'name' => $category->name
+            'name' => $category->name,
         ]);
     }
 
@@ -105,5 +104,4 @@ class CategoryControllerTest extends TestCase
 
         $response->assertOk();
     }
-
 }

--- a/tests/Feature/Http/Controllers/Api/V1/PostControllerTest.php
+++ b/tests/Feature/Http/Controllers/Api/V1/PostControllerTest.php
@@ -2,17 +2,17 @@
 
 namespace Tests\Feature\Http\Controllers\Api\V1;
 
-use Tests\TestCase;
+use App\Http\Middleware\Authenticate;
+use App\Models\Category;
 use App\Models\Post;
 use App\Models\User;
-use App\Models\Category;
-use App\Http\Middleware\Authenticate;
-use App\Repositories\Post\PostRepository;
-use Illuminate\Foundation\Testing\WithFaker;
 use App\Repositories\Category\CategoryRepository;
-use App\Repositories\Post\EloquentPostRepository;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use App\Repositories\Category\EloquentCategoryRepository;
+use App\Repositories\Post\EloquentPostRepository;
+use App\Repositories\Post\PostRepository;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
 
 class PostControllerTest extends TestCase
 {
@@ -20,6 +20,7 @@ class PostControllerTest extends TestCase
     use WithFaker;
 
     protected $user;
+
     protected $categories;
 
     protected function setUp(): void
@@ -35,7 +36,6 @@ class PostControllerTest extends TestCase
         $this->app->bind(PostRepository::class, EloquentPostRepository::class);
     }
 
-
     /** @test */
     public function user_can_get_list_of_posts()
     {
@@ -46,7 +46,7 @@ class PostControllerTest extends TestCase
 
         $response->assertOk();
         $response->assertJsonFragment([
-            'title' => $posts->random()->title
+            'title' => $posts->random()->title,
         ]);
     }
 
@@ -61,7 +61,7 @@ class PostControllerTest extends TestCase
         $response->assertOk();
         $response->assertJsonFragment([
             'title' => $post->title,
-            'content' => $post->content
+            'content' => $post->content,
         ]);
     }
 
@@ -71,7 +71,7 @@ class PostControllerTest extends TestCase
         $data = [
             'title' => $this->faker->sentence(),
             'content' => $this->faker->sentence(24),
-            'category' => $this->categories->random()->id
+            'category' => $this->categories->random()->id,
         ];
 
         $response = $this->actingAs($this->user)
@@ -87,7 +87,7 @@ class PostControllerTest extends TestCase
         $response->assertCreated();
         $response->assertJsonFragment([
             'title' => $data['title'],
-            'content' => $data['content']
+            'content' => $data['content'],
         ]);
     }
 
@@ -97,13 +97,13 @@ class PostControllerTest extends TestCase
         $oldData = [
             'title' => $this->faker->sentence(),
             'content' => $this->faker->sentence(24),
-            'category' => $this->categories->random()->id
+            'category' => $this->categories->random()->id,
         ];
 
         $newData = [
             'title' => $this->faker->sentence(),
             'content' => $this->faker->sentence(24),
-            'category' => $this->categories->random()->id
+            'category' => $this->categories->random()->id,
         ];
 
         $post = $this->user->posts()->create($oldData);
@@ -123,7 +123,7 @@ class PostControllerTest extends TestCase
         $response->assertOk();
         $response->assertJsonFragment([
             'title' => $newData['title'],
-            'content' => $newData['content']
+            'content' => $newData['content'],
         ]);
     }
 
@@ -131,7 +131,7 @@ class PostControllerTest extends TestCase
     public function user_can_delete_a_post()
     {
         $post = Post::factory()->create([
-            'user_id' => $this->user->id
+            'user_id' => $this->user->id,
         ]);
 
         $response = $this->actingAs($this->user)
@@ -141,8 +141,5 @@ class PostControllerTest extends TestCase
 
         $response->assertOk();
         $response->assertJsonFragment(['OK']);
-
     }
-
-
 }

--- a/tests/Feature/Http/Controllers/CategoryControllerTest.php
+++ b/tests/Feature/Http/Controllers/CategoryControllerTest.php
@@ -3,14 +3,12 @@
 namespace Tests\Feature\Http\Controllers;
 
 use App\Models\Category;
-use Tests\TestCase;
 use App\Models\User;
 use App\Repositories\Category\CategoryRepository;
 use App\Repositories\Category\EloquentCategoryRepository;
-use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Mockery;
-use Mockery\MockInterface;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
 
 class CategoryControllerTest extends TestCase
 {
@@ -45,7 +43,7 @@ class CategoryControllerTest extends TestCase
     public function user_can_store_a_category()
     {
         $data = [
-            'name' => $this->faker->sentence(2)
+            'name' => $this->faker->sentence(2),
         ];
 
         $response = $this->actingAs($this->user)
@@ -59,11 +57,11 @@ class CategoryControllerTest extends TestCase
     public function user_can_update_a_category()
     {
         $oldData = [
-            'name' => $this->faker->sentence(2)
+            'name' => $this->faker->sentence(2),
         ];
 
         $newData = [
-            'name' => $this->faker->sentence(2)
+            'name' => $this->faker->sentence(2),
         ];
 
         $category = Category::factory()->create($oldData);
@@ -81,7 +79,7 @@ class CategoryControllerTest extends TestCase
     public function user_can_delete_a_category()
     {
         $category = Category::factory()->create([
-            'user_id' => $this->user->id
+            'user_id' => $this->user->id,
         ]);
 
         $response = $this->actingAs($this->user)

--- a/tests/Feature/Http/Controllers/PostControllerTest.php
+++ b/tests/Feature/Http/Controllers/PostControllerTest.php
@@ -2,15 +2,15 @@
 
 namespace Tests\Feature\Http\Controllers;
 
-use Tests\TestCase;
+use App\Models\Category;
 use App\Models\Post;
 use App\Models\User;
-use App\Models\Category;
-use Illuminate\Foundation\Testing\WithFaker;
 use App\Repositories\Category\CategoryRepository;
+use App\Repositories\Category\EloquentCategoryRepository;
 use App\Repositories\Post\EloquentPostRepository;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use App\Repositories\Category\EloquentCategoryRepository;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
 
 class PostControllerTest extends TestCase
 {
@@ -18,6 +18,7 @@ class PostControllerTest extends TestCase
     use WithFaker;
 
     protected $user;
+
     protected $categories;
 
     protected function setUp(): void
@@ -30,7 +31,6 @@ class PostControllerTest extends TestCase
         $this->app->bind(CategoryRepository::class, EloquentCategoryRepository::class);
         $this->app->bind(PostRepository::class, EloquentPostRepository::class);
     }
-
 
     /** @test */
     public function user_can_view_posts_list()
@@ -65,7 +65,7 @@ class PostControllerTest extends TestCase
         $data = [
             'title' => $this->faker->sentence(),
             'content' => $this->faker->sentence(24),
-            'category' => $this->categories->random()->id
+            'category' => $this->categories->random()->id,
         ];
 
         $response = $this->actingAs($this->user)
@@ -87,13 +87,13 @@ class PostControllerTest extends TestCase
         $oldData = [
             'title' => $this->faker->sentence(),
             'content' => $this->faker->sentence(24),
-            'category' => $this->categories->random()->id
+            'category' => $this->categories->random()->id,
         ];
 
         $newData = [
             'title' => $this->faker->sentence(),
             'content' => $this->faker->sentence(24),
-            'category' => $this->categories->random()->id
+            'category' => $this->categories->random()->id,
         ];
 
         $post = $this->user->posts()->create($oldData);
@@ -117,7 +117,7 @@ class PostControllerTest extends TestCase
     public function user_can_delete_a_post()
     {
         $post = Post::factory()->create([
-            'user_id' => $this->user->id
+            'user_id' => $this->user->id,
         ]);
 
         $response = $this->actingAs($this->user)
@@ -126,8 +126,5 @@ class PostControllerTest extends TestCase
         $this->assertDatabaseMissing('posts', $post->toArray());
 
         $response->assertRedirect(route('posts.index'));
-
     }
-
-
 }


### PR DESCRIPTION
Shift automatically applies the Laravel coding style - which uses the PSR-12 coding style as a base with some minor additions.

You may customize the code style applied by configuring [Pint](https://laravel.com/docs/pint), [PHP CS Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer), or [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) for your project root.

For more information on customizing the code style applied by Shift, [watch this short video](https://laravelshift.com/videos/shift-code-style).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Code organization and import statement reordering across multiple files.
  * Enhanced model factory support with trait additions.
  * Repository method additions for category management operations.
  * Removed unnecessary docblock annotations.

* **Tests**
  * Improved test setup with enhanced configuration and repository bindings.
  * Extended test infrastructure for better test isolation and data management.

* **Style**
  * Applied consistent code formatting including trailing commas in array definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->